### PR TITLE
Make rules_docker M1 compatible

### DIFF
--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -31,6 +31,8 @@ def go_deps():
     already.
     """
     excludes = native.existing_rules().keys()
+    # go_register_toolchains can only be called once
+    # so we check that we only call it if it hasn't been before
     sdk_kinds = ("_go_download_sdk", "_go_host_sdk", "_go_local_sdk", "_go_wrap_sdk")
     existing_rules = native.existing_rules()
     sdk_rules = [r for r in existing_rules.values() if r["kind"] in sdk_kinds]

--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -30,10 +30,15 @@ def go_deps():
     'repositories' in //repositories:repositories.bzl have been imported
     already.
     """
-    go_rules_dependencies()
-    go_register_toolchains()
-    gazelle_dependencies()
     excludes = native.existing_rules().keys()
+    sdk_kinds = ("_go_download_sdk", "_go_host_sdk", "_go_local_sdk", "_go_wrap_sdk")
+    existing_rules = native.existing_rules()
+    sdk_rules = [r for r in existing_rules.values() if r["kind"] in sdk_kinds]
+    if len(sdk_rules) == 0:
+        go_rules_dependencies()
+        go_register_toolchains(version = "1.17.6")
+    
+    gazelle_dependencies()
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(
             name = "com_github_google_go_containerregistry",

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -111,10 +111,10 @@ def repositories():
     if "io_bazel_rules_go" not in excludes:
         http_archive(
             name = "io_bazel_rules_go",
-            sha256 = "08c3cd71857d58af3cda759112437d9e63339ac9c6e0042add43f4d94caf632d",
+            sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
             urls = [
-                "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.24.2/rules_go-v0.24.2.tar.gz",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.24.2/rules_go-v0.24.2.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
             ],
         )
     if "rules_python" not in excludes:
@@ -178,8 +178,11 @@ def repositories():
     if "bazel_gazelle" not in excludes:
         http_archive(
             name = "bazel_gazelle",
-            sha256 = "cdb02a887a7187ea4d5a27452311a75ed8637379a1287d8eeb952138ea485f7d",
-            urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz"],
+            sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+            ],
         )
 
     if "rules_pkg" not in excludes:

--- a/toolchains/docker/BUILD
+++ b/toolchains/docker/BUILD
@@ -42,7 +42,7 @@ docker_toolchain(
 toolchain(
     name = "default_linux_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:linux",
+        "@platforms//os:linux",
     ],
     toolchain = "@docker_config//:toolchain",
     toolchain_type = ":toolchain_type",
@@ -51,7 +51,7 @@ toolchain(
 toolchain(
     name = "default_windows_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:windows",
+        "@platforms//os:windows",
     ],
     toolchain = "@docker_config//:toolchain",
     toolchain_type = ":toolchain_type",
@@ -60,7 +60,7 @@ toolchain(
 toolchain(
     name = "default_osx_toolchain",
     target_compatible_with = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     toolchain = "@docker_config//:toolchain",
     toolchain_type = ":toolchain_type",


### PR DESCRIPTION
This resolves the error
```
ERROR: /Users/smocherla/repos/rules_docker/container/go/cmd/extract_config/BUILD:19:11: While resolving toolchains for target //container/go/cmd/extract_config:go_default_library: no matching toolchains found for types @io_bazel_rules_go//go:toolchain
```
by upgrading rules_go and gazelle in rules_docker. I've created a `brex-main` branch which maps to the currently used version of rules_docker at Brex. we can create a new tag with this fix so that we don't need to upgrade gazelle/rules_go in our consumer repositories.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

