### PR TITLE
Fix breakage with latest rules_go

### DIFF
--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -31,9 +31,9 @@ def go_deps():
     already.
     """
     excludes = native.existing_rules().keys()
-    # go_register_toolchains can only be called once
+    # go_register_toolchains can only be called once with the default SDK
     # so we check that we only call it if it hasn't been before
-    sdk_kinds = ("_go_download_sdk", "_go_host_sdk", "_go_local_sdk", "_go_wrap_sdk")
+    sdk_kinds = ("go_download_sdk_rule", "go_host_sdk_rule", "_go_local_sdk", "_go_wrap_sdk")
     existing_rules = native.existing_rules()
     sdk_rules = [r for r in existing_rules.values() if r["kind"] in sdk_kinds]
     if len(sdk_rules) == 0:


### PR DESCRIPTION
The repository rules to register go toolchains changed with latest release of rules_go to support [bzlmod changes.](https://github.com/bazelbuild/rules_go/commit/d756ad91feb9ca43800e781ab29c117623abed90) This breaks our upgrade to rules_go with this error
```
**({})".format(", ".join([r["name"] for r in sdk_rules])))
Error in fail: go_register_toolchains: version set after go sdk rule declared (go_sdk)**
```

This aims to fix that error. We need to get off this fork and use the latest version of rules_docker but that's a problem for another day.
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

